### PR TITLE
Fix compatibility with numpy 1.24

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,4 +7,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.19'
+- '1.21'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,14 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,15 +24,18 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -53,6 +56,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -39,16 +39,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `urdfpy` can be installed with:
+Once the `conda-forge` channel has been enabled, `urdfpy` can be installed with `conda`:
 
 ```
 conda install urdfpy
 ```
 
-It is possible to list all of the versions of `urdfpy` available on your platform with:
+or with `mamba`:
+
+```
+mamba install urdfpy
+```
+
+It is possible to list all of the versions of `urdfpy` available on your platform with `conda`:
 
 ```
 conda search urdfpy --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search urdfpy --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search urdfpy --channel conda-forge
+
+# List packages depending on `urdfpy`:
+mamba repoquery whoneeds urdfpy --channel conda-forge
+
+# List dependencies of `urdfpy`:
+mamba repoquery depends urdfpy --channel conda-forge
 ```
 
 
@@ -66,10 +91,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/24.patch
+++ b/recipe/24.patch
@@ -1,0 +1,22 @@
+diff --git a/urdfpy/urdf.py b/urdfpy/urdf.py
+index 14b0216..b5245e7 100644
+--- a/urdfpy/urdf.py
++++ b/urdfpy/urdf.py
+@@ -895,7 +895,7 @@ def color(self):
+     @color.setter
+     def color(self, value):
+         if value is not None:
+-            value = np.asanyarray(value).astype(np.float)
++            value = np.asanyarray(value).astype(np.float64)
+             value = np.clip(value, 0.0, 1.0)
+             if value.shape != (4,):
+                 raise ValueError('Color must be a (4,) float')
+@@ -2344,7 +2344,7 @@ def get_child_pose(self, cfg=None):
+             raise ValueError('Invalid configuration')
+ 
+     def get_child_poses(self, cfg, n_cfgs):
+-        """Computes the child pose relative to a parent pose for a given set of 
++        """Computes the child pose relative to a parent pose for a given set of
+         configuration values.
+ 
+         Parameters

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,11 @@ source:
   patches:
     - relax_pycollada_req.patch
     - unpin_networkx.patch
+    # Fix compatibility with numpy 1.24
+    - 24.patch
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
Backport https://github.com/mmatl/urdfpy/pull/24 to fix numpy 1.24 incompatibility.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

